### PR TITLE
Author のリンク先を Twitter から GitHub プロフィールに変更

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,4 +26,4 @@
 
 
 ## Author
-[Dillen H. Tomida](https://twitter.com/t0mihir0)
+[Dillen H. Tomida](https://github.com/yuki9431)


### PR DESCRIPTION
## 背景
ブログドメイン `grimoire.tokyo` / `grimoire.f5.si` は閉鎖済み(DNS 解決不可)。また Author のリンク先を Twitter から GitHub プロフィールに統一する。

## 変更
 README.md | 2 +-
 1 file changed, 1 insertion(+), 1 deletion(-)

## 検証
- `grep -rn 'grimoire|twitter.com/(t0mihir0|cafe_yuki)'` → 全リポジトリで残存 0 件
- 変更は README.md のみ